### PR TITLE
ci: fix wrong action version notifier

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
           private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
To fix this:

![image](https://github.com/statnett/workflows/assets/1142578/ec8b6a61-841a-469f-9dd1-23178ab61a81)
