### PR TITLE
ci: attempt to enable for releases

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -3,6 +3,11 @@ name: Lint PR
 
 on:
   workflow_call: {}
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   pr-title-lint:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,13 +15,34 @@ on:
         required: true
       STATNETT_BOT_PRIVATE_KEY:
         required: true
-
+    outputs:
+      releases_created:
+        description: true if the release was created, false otherwise
+        value: ${{ jobs.release-please.outputs.releases_created }}
+      major:
+        description: Number representing major semver value
+        value: ${{ jobs.release-please.outputs.major }}
+      minor:
+        description: Number representing minor semver value
+        value: ${{ jobs.release-please.outputs.minor }}
+      patch:
+        description: Number representing patch semver value
+        value: ${{ jobs.release-please.outputs.patch }}
+      sha:
+        description: sha that a GitHub release was tagged at
+        value: ${{ jobs.release-please.outputs.sha }}
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
+      patch: ${{ steps.release.outputs.patch }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - id: token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
@@ -29,7 +50,8 @@ jobs:
           app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
           private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
 
-      - uses: google-github-actions/release-please-action@4c5670f886fe259db4d11222f7dff41c1382304d # v3.7.12
+      - id: release
+        uses: google-github-actions/release-please-action@4c5670f886fe259db4d11222f7dff41c1382304d # v3.7.12
         with:
           bump-minor-pre-major: ${{ inputs.bump-minor-pre-major }}
           release-type: ${{ inputs.release-type }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,10 +25,10 @@ jobs:
       - run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git tag -d v${{ steps.release.outputs.major }} || true
-          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
-          git push origin :v${{ steps.release.outputs.major }} || true
-          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git tag --delete v${{ steps.release.outputs.major }} || true
+          git tag --delete v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git push --delete origin v${{ steps.release.outputs.major }} || true
+          git push --delete origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
           git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
           git push origin v${{ steps.release.outputs.major }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+---
+name: Release
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release-please:
+    uses: ./.github/workflows/release-please.yaml
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+
+  tag-major-minor:
+    runs-on: ubuntu-latest
+    needs: release-please
+    permissions:
+      contents: write
+    if: ${{ needs.release-please.outputs.releases_created }}
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -d v${{ steps.release.outputs.major }} || true
+          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git push origin :v${{ steps.release.outputs.major }} || true
+          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
+          git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
+          git push origin v${{ steps.release.outputs.major }}
+          git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}


### PR DESCRIPTION
For creating major and minor tags I am trying out https://github.com/google-github-actions/release-please-action#creating-majorminor-tags.

Also enabling linting of PR titles, as that is important for getting good release notes (changelog).