### PR TITLE
revert: "chore(deps): update google-github-actions/release-please-action action to v4"

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,7 +55,7 @@ jobs:
           private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
 
       - id: release
-        uses: google-github-actions/release-please-action@a6d1fd9854c8c40688a72f7e4b072a1e965860a0 # v4.0.0
+        uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         with:
           bump-minor-pre-major: ${{ inputs.bump-minor-pre-major }}
           extra-files: ${{ inputs.extra-files }}


### PR DESCRIPTION
Reverts statnett/github-workflows#44

It seems like I was too fast merging the major version upgrade. We should look closer at https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4 before attempting to upgrade again.