### PR TITLE
feat: add manifest-file input to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -6,12 +6,18 @@ on:
       release-type:
         type: string
         default: simple
+      manifest-file:
+        type: string
+        description: path to the release-please versions manifest
+        default: .release-please-manifest.json
       bump-minor-pre-major:
         type: boolean
         default: true
+        deprecationMessage: should be specified in manifest-file
       extra-files:
         type: string
         description: add extra-files to bump using the release-please generic updater
+        deprecationMessage: should be specified in manifest-file
     secrets:
       STATNETT_BOT_APP_ID:
         required: true
@@ -59,5 +65,6 @@ jobs:
         with:
           bump-minor-pre-major: ${{ inputs.bump-minor-pre-major }}
           extra-files: ${{ inputs.extra-files }}
+          manifest-file: ${{ inputs.manifest-file }}
           release-type: ${{ inputs.release-type }}
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
In the new major version of release-please-action, "advanced" parameters are not supported anymore and have to be specified in the release-please manifest file. This adds a new `manifest-file` input to the reusable release-please workflow and deprecates the inputs that will not be supported when upgrading release-please-action.

Migration docs from release-please-action: https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4