### PR TITLE
fix: don't use digests for CodeQL actions

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -63,6 +63,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@03e7845b7bfcd5e7fb63d1ae8c61b0e791134fab # v2.22.11
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
In an attempt to fix "imposter commit" problem. Example: https://github.com/statnett/image-scanner-operator/actions/runs/7204949563/job/19627161616