### PR TITLE
fix: use new project location for release-please-action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -54,7 +54,7 @@ jobs:
           private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
 
       - id: release
-        uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
+        uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:
           config-file: ${{ inputs.config-file }}
           manifest-file: ${{ inputs.manifest-file }}


### PR DESCRIPTION
Project is moved to a new location: https://github.com/google-github-actions/release-please-action