### PR TITLE
fix: snok/container-retention-policy cut-off param default after new major release

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       cut-off:
         type: string
-        default: A week ago UTC
+        default: 7days
         description: The timezone-aware datetime you want to delete container versions that are older than.
 
 permissions: {}


### PR DESCRIPTION
It seems like snok has migrated from Python to Rust in the new major version, and the time format has changed.

This is the time-library now used: https://crates.io/crates/humantime