### PR TITLE
fix: migrate tibdex/github-app-token -> create-github-app-token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -48,10 +48,10 @@ jobs:
       sha: ${{ steps.release.outputs.sha }}
     steps:
       - id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
-          private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.STATNETT_BOT_APP_ID }}
+          private-key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
 
       - id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0


### PR DESCRIPTION
https://github.com/tibdex/github-app-token is deprecated:

<img width="936" height="151" alt="image" src="https://github.com/user-attachments/assets/5f28854f-af1c-4135-8fb6-02a9c3af9e25" />

in favour of https://github.com/actions/create-github-app-token